### PR TITLE
Fix version text in dropdown

### DIFF
--- a/src/components/version-switcher.tsx
+++ b/src/components/version-switcher.tsx
@@ -38,13 +38,13 @@ export function VersionSwitcher({
               </div>
               <div className="flex flex-col gap-0.5 leading-none">
                 <span className="font-medium">Documentation</span>
-                <span className="">v{selectedVersion}</span>
+                <span className="">{`v${selectedVersion}`}</span>
               </div>
               <ChevronsUpDown className="ml-auto" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width)"
+            className="w-[--radix-dropdown-menu-trigger-width]"
             align="start"
           >
             {versions.map((version) => (
@@ -52,7 +52,7 @@ export function VersionSwitcher({
                 key={version}
                 onSelect={() => setSelectedVersion(version)}
               >
-                v{version}{" "}
+                {`v${version} `}
                 {version === selectedVersion && <Check className="ml-auto" />}
               </DropdownMenuItem>
             ))}


### PR DESCRIPTION
## Summary
- fix string interpolation in version switcher

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684178e8795483299476d612c1d7d373