### PR TITLE
Fix header class name spacing in demo page

### DIFF
--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
     <SidebarProvider>
       <AppSidebar />
       <SidebarInset>
-        <header className="flex   items-center gap-2 ">
+        <header className="flex items-center gap-2">
           <SidebarTrigger className="-ml-1" />
           <Separator
             orientation="vertical"


### PR DESCRIPTION
## Summary
- adjust header className in demo page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417d02ded48329835d68ddcd4918c6